### PR TITLE
Refactor dump1090 to a library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
-CFLAGS?=-O2 -g -Wall -W $(shell pkg-config --cflags librtlsdr)
-LDLIBS+=$(shell pkg-config --libs librtlsdr) -lpthread -lm
 CC?=gcc
-PROGNAME=dump1090
+CFLAGS?=-O2 -g -Wall -W -fPIC $(shell pkg-config --cflags librtlsdr)
+LDFLAGS?=$(shell pkg-config --libs librtlsdr) -lpthread -lm
+OBJS=dump1090.o anet.o
 
-all: dump1090
+all: libdump1090.a libdump1090.so dump1090
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
 
-dump1090: dump1090.o anet.o
-	$(CC) -g -o dump1090 dump1090.o anet.o $(LDFLAGS) $(LDLIBS)
+libdump1090.a: $(OBJS)
+	ar rcs $@ $(OBJS)
+
+libdump1090.so: $(OBJS)
+	$(CC) -shared -o $@ $(OBJS) $(LDFLAGS)
+
+dump1090: main.o libdump1090.a
+	$(CC) $(CFLAGS) -o $@ main.o libdump1090.a $(LDFLAGS)
 
 clean:
-	rm -f *.o dump1090
+	rm -f $(OBJS) main.o libdump1090.a libdump1090.so dump1090

--- a/dump1090.c
+++ b/dump1090.c
@@ -45,6 +45,7 @@
 #include <sys/select.h>
 #include "rtl-sdr.h"
 #include "anet.h"
+#include "dump1090.h"
 
 #define MODES_DEFAULT_RATE         2000000
 #define MODES_DEFAULT_FREQ         1090000000
@@ -2501,7 +2502,7 @@ void backgroundTasks(void) {
     }
 }
 
-int main(int argc, char **argv) {
+int dump1090_run(int argc, char **argv) {
     int j;
 
     /* Set sane defaults. */

--- a/dump1090.h
+++ b/dump1090.h
@@ -1,0 +1,65 @@
+#ifndef DUMP1090_H
+#define DUMP1090_H
+
+#include <stdint.h>
+
+struct modesMessage;
+struct aircraft;
+struct client;
+
+int dump1090_run(int argc, char **argv);
+void modesInitConfig(void);
+void modesInit(void);
+void modesInitRTLSDR(void);
+void rtlsdrCallback(unsigned char *buf, uint32_t len, void *ctx);
+void readDataFromFile(void);
+void *readerThreadEntryPoint(void *arg);
+void dumpMagnitudeBar(int index, int magnitude);
+void dumpMagnitudeVector(uint16_t *m, uint32_t offset);
+uint32_t modesChecksum(unsigned char *msg, int bits);
+int modesMessageLenByType(int type);
+int fixSingleBitErrors(unsigned char *msg, int bits);
+int fixTwoBitsErrors(unsigned char *msg, int bits);
+uint32_t ICAOCacheHashAddress(uint32_t a);
+void addRecentlySeenICAOAddr(uint32_t addr);
+int ICAOAddressWasRecentlySeen(uint32_t addr);
+int bruteForceAP(unsigned char *msg, struct modesMessage *mm);
+int decodeAC13Field(unsigned char *msg, int *unit);
+int decodeAC12Field(unsigned char *msg, int *unit);
+char *getMEDescription(int metype, int mesub);
+void decodeModesMessage(struct modesMessage *mm, unsigned char *msg);
+void displayModesMessage(struct modesMessage *mm);
+void computeMagnitudeVector(void);
+int detectOutOfPhase(uint16_t *m);
+void applyPhaseCorrection(uint16_t *m);
+void detectModeS(uint16_t *m, uint32_t mlen);
+void useModesMessage(struct modesMessage *mm);
+struct aircraft *interactiveCreateAircraft(uint32_t addr);
+struct aircraft *interactiveFindAircraft(uint32_t addr);
+int cprModFunction(int a, int b);
+int cprNLFunction(double lat);
+int cprNFunction(double lat, int isodd);
+double cprDlonFunction(double lat, int isodd);
+void decodeCPR(struct aircraft *a);
+struct aircraft *interactiveReceiveData(struct modesMessage *mm);
+void interactiveShowData(void);
+void interactiveRemoveStaleAircrafts(void);
+void snipMode(int level);
+void modesInitNet(void);
+void modesAcceptClients(void);
+void modesFreeClient(int fd);
+void modesSendAllClients(int service, void *msg, int len);
+void modesSendRawOutput(struct modesMessage *mm);
+void modesSendSBSOutput(struct modesMessage *mm, struct aircraft *a);
+int hexDigitVal(int c);
+int decodeHexMessage(struct client *c);
+char *aircraftsToJson(int *len);
+int handleHTTPRequest(struct client *c);
+void modesReadFromClients(void);
+void modesWaitReadableClients(int timeout_ms);
+void sigWinchCallback(void);
+int getTermRows(void);
+void showHelp(void);
+void backgroundTasks(void);
+
+#endif /* DUMP1090_H */

--- a/main.c
+++ b/main.c
@@ -1,0 +1,6 @@
+#include "dump1090.h"
+
+int main(int argc, char **argv) {
+    return dump1090_run(argc, argv);
+}
+


### PR DESCRIPTION
## Summary
- expose dump1090 functionality via new dump1090_run entry point
- add public header declaring all non-static functions
- provide Makefile building static and shared libraries and executable wrapper
- add main.c wrapper that forwards to dump1090_run

## Testing
- `make` *(fails: rtl-sdr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891bf072f0c8323bfef6faf6c86e5d0